### PR TITLE
Fix typos and add default argument

### DIFF
--- a/lumina_next_t2i/configs/infer/settings.yaml
+++ b/lumina_next_t2i/configs/infer/settings.yaml
@@ -25,6 +25,6 @@
       solver: "euler"               # option: ["euler", "dopri5", "dopri8"]
       t_shift: 4                    # range: 1-20 (int only)
       scaling_method: "Time-aware"  # option: ["Time-aware", "None"]
-      scale_watershed: 0.3          # range: 0.0-1.0
+      scaling_watershed: 0.3        # range: 0.0-1.0
       proportional_attn: true       # option: true or false
       seed: 0                       # rnage: any number

--- a/lumina_next_t2i/entry_point.py
+++ b/lumina_next_t2i/entry_point.py
@@ -53,7 +53,7 @@ global_options = [
         "-c",
         "--config",
         type=str,
-        default="cofing/infer/settings.yaml",
+        default="config/infer/settings.yaml",
         help="setting for inference with different parameter.",
     ),
     click.option(

--- a/lumina_next_t2i/sample.py
+++ b/lumina_next_t2i/sample.py
@@ -161,13 +161,13 @@ def main(args, rank, master_port):
         collected_id = []
 
     captions = []
-
+    print(args.caption_path)
     with open(args.caption_path, "r", encoding="utf-8") as file:
         for line in file:
             text = line.strip()
             if text:
                 captions.append(line.strip())
-
+    print(captions)
     total = len(info)
     resolution = args.resolution
     with torch.autocast("cuda", dtype):
@@ -308,7 +308,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--resolution",
         type=str,
-        default="",
+        default=["1024:1024x1024"],
         nargs="+",
     )
     parser.add_argument(


### PR DESCRIPTION
This PR addresses several small issues that were encountered while running the lumina_next_t21. The changes improve the overall execution flow and fix minor typos in the codebase.

- Set a default value for `--resolution` in `samples.py`, as the expected format of resolution  was not intuitive
- **Resolved typo in config argument:** Corrected `cofing` to `config` in `entry_point.py`
- **Updated key naming for consistency:** Renamed `scale_watershed` to `scaling_watershed` in `setting.yaml`